### PR TITLE
add names to symlink

### DIFF
--- a/calculateContamination.wdl
+++ b/calculateContamination.wdl
@@ -123,17 +123,19 @@ task getMetrics{
 
     command <<<
 
-ln -s ~{tumorBaiFile} .
-ln -s ~{normalBaiFile} .
+ln -s ~{tumorBamFile} ./tumorBamFile.bam
+ln -s ~{tumorBaiFile} ./tumorBamFile.bam.bai
+ln ~{normalBamFile} ./normalBamFile.bam
+ln ~{normalBaiFile} ./normalBamFile.bam.bai
 
 $GATK_ROOT/bin/gatk GetPileupSummaries \
--I ~{tumorBamFile} \
+-I ./tumorBamFile.bam \
 -V ~{refVCF} \
 -L ~{refVCF} \
 -O tumor.summaries.table
 
 $GATK_ROOT/bin/gatk GetPileupSummaries \
--I ~{normalBamFile} \
+-I ./normalBamFile.bam \
 -V ~{refVCF} \
 -L ~{refVCF} \
 -O normal.summaries.table
@@ -183,14 +185,12 @@ task tumorOnlyMetrics{
     }
 
     command <<<
-module unload cromwell #temp for local testing
-module unload java     #temp for local testing
-module load ~{modules}
 
-ln -s ~{tumorBaiFile} .
+ln -s ~{tumorBamFile} ./tumorBamFile.bam
+ln -s ~{tumorBaiFile} ./tumorBamFile.bam.bai
 
 $GATK_ROOT/bin/gatk GetPileupSummaries \
--I ~{tumorBamFile} \
+-I ./tumorBamFile.bam \
 -V ~{refVCF} \
 -L ~{refVCF} \
 -O tumor.summaries.table

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -284,7 +284,7 @@
                     },
                     "fastq2": {
                         "contents": {
-                            "configuration": "//.mounts/labs/gsi/testdata/calculateContanimation/input/fastqs/tumor/CAPLOD_20210315-CAGAGAGG-TATCCTCT_1_2.fastq",
+                            "configuration": "/.mounts/labs/gsi/testdata/calculateContanimation/input/fastqs/tumor/CAPLOD_20210315-CAGAGAGG-TATCCTCT_1_2.fastq",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -311,7 +311,7 @@
                     },
                     "fastq2": {
                         "contents": {
-                            "configuration": "//.mounts/labs/gsi/testdata/calculateContanimation/input/fastqs/normal/CAPLOD_20210315-CAGAGAGG-TAGATCGC_1_2.fastq",
+                            "configuration": "/.mounts/labs/gsi/testdata/calculateContanimation/input/fastqs/normal/CAPLOD_20210315-CAGAGAGG-TAGATCGC_1_2.fastq",
                             "externalIds": [
                                 {
                                     "id": "TEST",


### PR DESCRIPTION
The symlink to bam and bai files should have explicit names in the same folder.
Testet locally: http://cromwell-job-manager-dev.gsi.oicr.on.ca:4200/jobs/5a01a5c9-dde4-45b2-a98e-401bd9b00bff?q=name%3DcalculateContamination